### PR TITLE
Added support for anonymous index components.

### DIFF
--- a/src/hoverProvider.ts
+++ b/src/hoverProvider.ts
@@ -9,7 +9,7 @@ import {
   workspace,
   ProviderResult,
 } from "vscode";
-import { nameToPath } from "./utils";
+import { nameToIndexPath, nameToPath } from "./utils";
 
 export default class HoverProvider implements BaseHoverProvider {
   public provideHover(
@@ -25,11 +25,15 @@ export default class HoverProvider implements BaseHoverProvider {
     }
 
     const componentName = doc.getText(range);
-    const componentPath = nameToPath(componentName);
     const workspacePath = workspace.getWorkspaceFolder(doc.uri)?.uri.fsPath;
-
+    let componentPath = nameToPath(componentName);
+    
     if (!existsSync(workspacePath + componentPath)) {
-      return;
+      componentPath = nameToIndexPath(componentName);
+      
+      if (!existsSync(workspacePath + componentPath)) {
+        return;
+      }
     }
 
     const lookUpUri = `[${componentPath}](${Uri.file(

--- a/src/linkProvider.ts
+++ b/src/linkProvider.ts
@@ -11,7 +11,7 @@ import {
   DocumentLink,
   Range,
 } from "vscode";
-import { nameToPath } from "./utils";
+import { nameToIndexPath, nameToPath } from "./utils";
 
 export default class LinkProvider implements DocumentLinkProvider {
   public provideDocumentLinks(
@@ -32,20 +32,26 @@ export default class LinkProvider implements DocumentLinkProvider {
 
       if (result !== null) {
         for (let componentName of result) {
-          const componentPath = nameToPath(componentName);
-
-          if (existsSync(workspacePath + componentPath)) {
-            let start = new Position(
-              line.lineNumber,
-              line.text.indexOf(componentName)
-            );
-            let end = start.translate(0, componentName.length);
-            let documentlink = new DocumentLink(
-              new Range(start, end),
-              Uri.file(workspacePath + componentPath)
-            );
-            documentLinks.push(documentlink);
+          let componentPath = nameToPath(componentName);
+          
+          if (!existsSync(workspacePath + componentPath)) {
+            componentPath = nameToIndexPath(componentName);
+            
+            if (!existsSync(workspacePath + componentPath)) {
+              continue;
+            }
           }
+          
+          let start = new Position(
+            line.lineNumber,
+            line.text.indexOf(componentName)
+          );
+          let end = start.translate(0, componentName.length);
+          let documentlink = new DocumentLink(
+            new Range(start, end),
+            Uri.file(workspacePath + componentPath)
+          );
+          documentLinks.push(documentlink);
         }
       }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,7 @@
 export function nameToPath(path: string): string {
   return `/resources/views/components/${path.replace(/\./g, "/")}.blade.php`;
 }
+
+export function nameToIndexPath(path: string): string {
+  return `/resources/views/components/${path.replace(/\./g, "/")}/index.blade.php`;
+}


### PR DESCRIPTION
This PR adds support for anonymous index components that were released in Laravel v8.62.

This has also been tested with a similar structure such as:
```
components/
  foo/
    bar/
      index.blade.php
      foobar.index.php
    bar.blade.php
```
When using `<x-foo.bar />`, Laravel processes the file first `foo/bar.blade.php` therefore, this implementation also prioritizes these files and `<x-foo.bar />` in this case will refer to `foo/bar.blade.php`

Without file `foo/bar.blade.php`: `<x-foo.bar />` will refer to `foo/bar/index.blade.php`